### PR TITLE
Support pry 0.12

### DIFF
--- a/lib/pry-moves/tracer.rb
+++ b/lib/pry-moves/tracer.rb
@@ -1,3 +1,5 @@
+require 'digest'
+
 require 'pry' unless defined? Pry
 
 module PryMoves
@@ -133,6 +135,6 @@ class Tracer
     @pry_start_options[:exit_from_method] = true
     true
   end
-  
+
 end
 end

--- a/lib/pry-stack_explorer/pry-stack_explorer.rb
+++ b/lib/pry-stack_explorer/pry-stack_explorer.rb
@@ -108,7 +108,7 @@ module PryStackExplorer
       (b1.eval('self').equal?(b2.eval('self'))) &&
         (b1.eval('__method__') == b2.eval('__method__')) &&
         (b1.eval('local_variables').map { |v| b1.eval("#{v}") }.equal?(
-         b2.eval('local_variables').map { |v| b2.eval("#{v}") }))
+        b2.eval('local_variables').map { |v| b2.eval("#{v}") }))
     end
   end
 end
@@ -124,14 +124,14 @@ Pry.config.commands.import PryStackExplorer::Commands
 
 # monkey-patch the whereami command to show some frame information,
 # useful for navigating stack.
-Pry.config.commands.before_command("whereami") do |num|
+Pry.config.hooks.add_hook(:before_whereami, :stack_explorer) do
   if PryStackExplorer.frame_manager(_pry_) && !internal_binding?(target)
     bindings      = PryStackExplorer.frame_manager(_pry_).bindings
     binding_index = PryStackExplorer.frame_manager(_pry_).binding_index
 
     info = "#{Pry::Helpers::Text.bold('Frame:')} "+
-        "#{binding_index}/#{bindings.size - 1} "+
-        "#{bindings[binding_index].frame_type}"
+      "#{binding_index}/#{bindings.size - 1} "+
+      "#{bindings[binding_index].frame_type}"
 
     output.puts "\n"
     output.puts info

--- a/pry-moves.gemspec
+++ b/pry-moves.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.required_ruby_version = '>= 1.8.7'
-  gem.add_runtime_dependency 'pry', '>= 0.10.4', '< 0.12.0'
+  gem.add_runtime_dependency 'pry', '>= 0.10.4', '< 0.13.0'
   gem.add_runtime_dependency 'binding_of_caller', '~> 0.7'
   gem.add_development_dependency 'pry-remote', '~> 0.1.6'
 end


### PR DESCRIPTION
Make pry-moves to support Pry 0.12.

BTW: Maybe i should create a PR from official ruby gems 0.1.10 code base,
But i am no idea about which commit is used, i am no see any git tag for this version,
Anyway,  Following is all i need to change to work with newest pry.

Thanks