### PR TITLE
Track forked pry-stack_explorer version

### DIFF
--- a/lib/pry-stack_explorer/VERSION
+++ b/lib/pry-stack_explorer/VERSION
@@ -1,0 +1,2 @@
+Forked and modified copy of pry-stack_explorer v0.4.9.
+Latest upstream merged: v0.4.9.3


### PR DESCRIPTION
Confirmed: All changes between 0.4.9 (origin of fork) and 0.4.9.3 are included in this embeded copy.

This VERSION file provides a point to diff this copy against to see what changes to upstream were made in this fork.